### PR TITLE
Feature/ble scan

### DIFF
--- a/backend/gatterserver/api.py
+++ b/backend/gatterserver/api.py
@@ -2,16 +2,20 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from gatterserver.ble.discovery import BLEDiscoveryManager
 from gatterserver.emitters.emittermanager import EmitterManager
-from gatterserver.routers import jsonposts, tests, websockets
+from gatterserver.routers import ble, jsonposts, tests, websockets
 
+discovery_manager = BLEDiscoveryManager()
 emitter_manger = EmitterManager()
 
+ble.register(discovery_manager)
 websockets.register(emitter_manger)
 jsonposts.register(emitter_manger)
 
 app = FastAPI()
 
+app.include_router(ble.router)
 app.include_router(tests.router)
 app.include_router(websockets.router)
 app.include_router(jsonposts.router)

--- a/backend/gatterserver/ble/discovery.py
+++ b/backend/gatterserver/ble/discovery.py
@@ -1,0 +1,55 @@
+"""Scan for BLE devices."""
+
+import asyncio
+import logging
+from typing import Callable, Dict
+
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BLEDiscoveryManager:
+    """Manage BLE Discovery."""
+
+    def __init__(self):
+        self._discovered: Dict[str, BLEDevice] = {}
+        self._last_discovery: BLEDevice = None
+        self._event = asyncio.Event()
+        self._scanner = BleakScanner(detection_callback=self._make_on_discovery())
+        self._task_handle: asyncio.Task = None
+
+    def _make_on_discovery(self) -> Callable[[BLEDevice, AdvertisementData], None]:
+        """Return the on_discovery callback."""
+
+        def _on_discovery(device: BLEDevice, advertisement: AdvertisementData):
+            """Callback on each BLE discovery."""
+            self._discovered[device.address] = device
+            self._last_discovery = device
+            self._event.set()
+
+        return _on_discovery
+
+    async def start_discovery(self):
+        """Start BLE discovery task."""
+        if self._task_handle != None:
+            LOGGER.warning("Discovery already running.")
+            return
+        self._task_handle = asyncio.create_task(self._scanner.start())
+
+    async def stop_discovery(self):
+        """Stop BLE discovery task."""
+        if self._task_handle == None:
+            LOGGER.warning("Discovery not running.")
+            return
+        await self._scanner.stop()
+        self._task_handle.cancel()
+        self._task_handle = None
+
+    async def receive(self) -> BLEDevice:
+        while True:
+            await self._event.wait()
+            self._event.clear()
+            yield self._last_discovery

--- a/backend/gatterserver/models/README.md
+++ b/backend/gatterserver/models/README.md
@@ -95,3 +95,69 @@
 }
 ```
 
+## A BLE device has been discovered
+
+`/api/ws/blediscovery`
+
+```json
+{
+  "title": "BLEDiscoveryMessage",
+  "type": "object",
+  "properties": {
+    "address": {
+      "title": "Address",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "rssi": {
+      "title": "Rssi",
+      "type": "string"
+    },
+    "services": {
+      "title": "Services",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "manufacturerData": {
+      "title": "Manufacturerdata",
+      "type": "string",
+      "format": "binary"
+    }
+  },
+  "required": [
+    "address",
+    "name",
+    "rssi",
+    "services",
+    "manufacturerData"
+  ],
+  "additionalProperties": false
+}
+```
+
+## Start or stop BLE discovery
+
+`/api/ble/discovery`
+
+```json
+{
+  "title": "DiscoveryCommand",
+  "type": "object",
+  "properties": {
+    "discovery": {
+      "title": "Discovery",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "discovery"
+  ],
+  "additionalProperties": false
+}
+```
+

--- a/backend/gatterserver/models/README.md
+++ b/backend/gatterserver/models/README.md
@@ -108,16 +108,21 @@
       "title": "Address",
       "type": "string"
     },
+    "rssi": {
+      "title": "Rssi",
+      "type": "integer"
+    },
+    "rssiAverage": {
+      "title": "Rssiaverage",
+      "type": "number"
+    },
     "name": {
       "title": "Name",
       "type": "string"
     },
-    "rssi": {
-      "title": "Rssi",
-      "type": "string"
-    },
     "services": {
       "title": "Services",
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"
@@ -125,16 +130,18 @@
     },
     "manufacturerData": {
       "title": "Manufacturerdata",
-      "type": "string",
-      "format": "binary"
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "format": "binary"
+      }
     }
   },
   "required": [
     "address",
-    "name",
     "rssi",
-    "services",
-    "manufacturerData"
+    "rssiAverage"
   ],
   "additionalProperties": false
 }

--- a/backend/gatterserver/models/__init__.py
+++ b/backend/gatterserver/models/__init__.py
@@ -1,10 +1,11 @@
 """Define pydantic/JSON models."""
 
 import os
-from typing import Literal
+from base64 import b64encode
+from typing import Any, Dict, List, Literal
 
 from gatterserver.streams import StreamId
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, validator
 
 API_CMD_ADD_PATH = os.environ["API_CMD_ADD_PATH"]
 API_CMD_DEL_PATH = os.environ["API_CMD_DEL_PATH"]
@@ -28,12 +29,38 @@ class StartStreamCommand(BaseModel, extra=Extra.forbid):
     streamId: StreamId
 
 
+class BLEDiscoveryMessage(BaseModel, extra=Extra.forbid):
+    address: str
+    rssi: int
+    name: str = None
+    services: List[str] = []
+    manufacturerData: Dict[int, bytes] = {}
+
+    @validator("manufacturerData", pre=True)
+    def decode_bytes(cls, v: Dict[int, bytes]):
+        for key, value in v.items():
+            if type(value) != bytes:
+                continue
+            v[key] = b64encode(value)
+        return v
+
+
+class DiscoveryCommand(BaseModel, extra=Extra.forbid):
+    discovery: bool
+
+
 if __name__ == "__main__":
     # Generate the README.md
     models_list = (
         (AddCommand, "Add a device or stream", API_CMD_ADD_PATH),
         (DeleteCommand, "Remove a device or stream", API_CMD_DEL_PATH),
         (StartStreamCommand, "Start a stream", API_CMD_START_STREAM_PATH),
+        (
+            BLEDiscoveryMessage,
+            "A BLE device has been discovered",
+            "/api/ws/blediscovery",
+        ),
+        (DiscoveryCommand, "Start or stop BLE discovery", "/api/ble/discovery"),
     )
 
     with open(f"{os.path.dirname(os.path.realpath(__file__))}/README.md", "w+") as file:

--- a/backend/gatterserver/models/__init__.py
+++ b/backend/gatterserver/models/__init__.py
@@ -32,6 +32,7 @@ class StartStreamCommand(BaseModel, extra=Extra.forbid):
 class BLEDiscoveryMessage(BaseModel, extra=Extra.forbid):
     address: str
     rssi: int
+    rssiAverage: float
     name: str = None
     services: List[str] = []
     manufacturerData: Dict[int, bytes] = {}

--- a/backend/gatterserver/routers/ble.py
+++ b/backend/gatterserver/routers/ble.py
@@ -27,6 +27,7 @@ async def websocket_endpoint(websocket: WebSocket):
             address=device.address,
             name=device.name,
             rssi=device.rssi,
+            rssiAverage=discovery_manager.get_average_rssi(device.address),
             services=device.metadata["uuids"],
             manufacturerData=device.metadata["manufacturer_data"],
         )

--- a/backend/gatterserver/routers/ble.py
+++ b/backend/gatterserver/routers/ble.py
@@ -1,0 +1,42 @@
+"""Routes for BLE discovery and connection."""
+
+import logging
+import sys
+
+from fastapi import APIRouter, WebSocket
+from fastapi.encoders import jsonable_encoder
+from gatterserver import models
+from gatterserver.ble.discovery import BLEDiscoveryManager
+
+LOGGER = logging.getLogger(__name__)
+
+router = APIRouter()
+
+discovery_manager: BLEDiscoveryManager = None
+
+
+def register(discovery_manager: BLEDiscoveryManager):
+    sys.modules[__name__].__dict__["discovery_manager"] = discovery_manager
+
+
+@router.websocket("/api/ws/blediscovery")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    async for device in discovery_manager.receive():
+        discovery_message = models.BLEDiscoveryMessage(
+            address=device.address,
+            name=device.name,
+            rssi=device.rssi,
+            services=device.metadata["uuids"],
+            manufacturerData=device.metadata["manufacturer_data"],
+        )
+        await websocket.send_json(jsonable_encoder(discovery_message))
+
+
+@router.post("/api/ble/discovery")
+async def ble_discovery_endpoint(command: models.DiscoveryCommand):
+    if command.discovery:
+        await discovery_manager.start_discovery()
+    else:
+        await discovery_manager.stop_discovery()
+    return command

--- a/backend/tests/test_blediscovery.py
+++ b/backend/tests/test_blediscovery.py
@@ -1,0 +1,50 @@
+"""Test BLE Discovery."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+from gatterserver.api import app
+from gatterserver.ble.discovery import BLEDiscoveryManager
+
+client = TestClient(app)
+
+
+def test_ble_discovery_manager_constructor():
+    bm = BLEDiscoveryManager()
+    assert bm
+    assert bm._discovered == {}
+    assert bm._last_discovery == None
+    assert type(bm._event) == asyncio.Event
+    assert bm._event.is_set() == False
+    assert bm._scanner != None
+    assert bm._task_handle == None
+
+
+@pytest.mark.asyncio
+async def test_ble_discovery_manager_starts_scanning():
+    bm = BLEDiscoveryManager()
+    bm._scanner.start = AsyncMock()
+
+    await bm.start_discovery()
+    bm._scanner.start.assert_called_once()
+    assert type(bm._task_handle) == asyncio.Task
+    assert bm._event.is_set() == False
+
+
+@pytest.mark.asyncio
+async def test_ble_discovery_manager_stops_scanning():
+    bm = BLEDiscoveryManager()
+    bm._scanner.start = AsyncMock()
+    bm._scanner.stop = AsyncMock()
+
+    await bm.start_discovery()
+    bm._scanner.start.assert_called_once()
+    assert type(bm._task_handle) == asyncio.Task
+    assert bm._event.is_set() == False
+
+    await bm.stop_discovery()
+    bm._scanner.stop.assert_called_once()
+    assert bm._task_handle == None
+    assert bm._event.is_set() == False

--- a/backend/tests/test_test_endpoints.py
+++ b/backend/tests/test_test_endpoints.py
@@ -1,5 +1,4 @@
 from fastapi.testclient import TestClient
-
 from gatterserver.api import app
 
 client = TestClient(app)


### PR DESCRIPTION
This adds the ability to start and stop BLE scanning via a POST route.  While scanning is active, discovered devices are streamed to the frontend via a websocket route.  It is the frontend's responsibility to keep track of them.  One device is sent at a time and they will repeat in a loop.  The only guaranteed unique parameter of each BLE device is its `address`, so BLE devices should be stored in a hash table keyed by their `address`.